### PR TITLE
change: corrected misspelled mongod command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ I've included a number of animations using plain CSS and `react-spring`. If you'
 
 ```sh
 # Run mongo
-sudo mognod
+sudo mongod
 
 # In ./server
 yarn install


### PR DESCRIPTION
README.md listed mongo instructions as the following:

# Run mongo
sudo mognod

I change it to the following:

# Run mongo
sudo mongod